### PR TITLE
Default Dark Mode + Hover and On-Target Color Changes

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,6 +23,7 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install --only-upgrade python3-pip
+          sudo python -m pip install -e .
           sudo python -m pip install -r docs/requirements.txt
           cd docs && make html
       - name: Setup Pages
@@ -37,7 +38,7 @@ jobs:
       - name: Upload rendered docs
         uses: actions/upload-pages-artifact@v3.0.1
         with:
-          path: ./docs/build
+          path: ./docs/build/html
         if: always()
   deploy-docs:
     environment:

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -44,8 +44,8 @@ html_theme_options = {
         "color-brand-primary": "#e2ad2b", # Primary brand color
         "color-brand-content": "#e2ad2b", # Link color
         "color-link": "#e2ad2b", # Normal links
-        "color-link-hover": "#e0b027", # Hover state
-        "color-link-visited": "#d0d0d0", # Visited links
+        "color-link-hover": "#ffffff", # Hover state
+        "color-link-visited": "#CEAFF4", # Visited links
         
         # Sidebar colors
         "color-sidebar-link-text": "#e0b027", # Sidebar link color

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -45,7 +45,7 @@ html_theme_options = {
         "color-brand-content": "#e2ad2b",  # Link color
         "color-link": "#e2ad2b",  # Normal links
         "color-link-hover": "#CEAFF4",  # Hover state
-        "color-link-visited": "#CEAFF4",  # Visited links
+        "color-link--visited": "#CEAFF4",  # Visited links
         # Sidebar colors
         "color-sidebar-link-text": "#e0b027",  # Sidebar link color
         "color-sidebar-link-text--top-level": "#e2ad2b",  # Top level sidebar links

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -13,7 +13,7 @@ sys.path.insert(0, os.path.abspath('../../src'))
 project = 'hello-whorl'
 copyright = '2025 hello-whorl'
 author = 'Preston Smith, Aidan Dyga, Rebekah Rudd, Jason Gyamafi'
-release = '1.0.0'
+release = '0.0.13'
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
@@ -31,13 +31,13 @@ language = 'python'
 html_theme = 'furo'
 html_static_path = ['_static']
 html_theme_options = {
-    "light_css_variables": {
+    "dark_css_variables": {
         # Background colors
-        "color-background-primary": "#262932",  # Main content background
-        "color-background-secondary": "#262932", # Sidebar background
+        "color-background-primary": "#202020",  # Main content background
+        "color-background-secondary": "#202020", # Sidebar background
         
         # Text colors
-        "color-foreground-primary": "#ffffff", # Main text color
+        "color-foreground-primary": "#d0d0d0", # Main text color
         "color-foreground-secondary": "#e0b027", # Secondary text color
         
         # Link colors
@@ -45,7 +45,7 @@ html_theme_options = {
         "color-brand-content": "#e2ad2b", # Link color
         "color-link": "#e2ad2b", # Normal links
         "color-link-hover": "#e0b027", # Hover state
-        "color-link-visited": "#e2ad2b", # Visited links
+        "color-link-visited": "#d0d0d0", # Visited links
         
         # Sidebar colors
         "color-sidebar-link-text": "#e0b027", # Sidebar link color

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -8,52 +8,50 @@
 
 import os
 import sys
-sys.path.insert(0, os.path.abspath('../../src'))
 
-project = 'hello-whorl'
-copyright = '2025 hello-whorl'
-author = 'Preston Smith, Aidan Dyga, Rebekah Rudd, Jason Gyamafi'
-release = '0.0.13'
+sys.path.insert(0, os.path.abspath("../../src"))
+
+project = "hello-whorl"
+copyright = "2025 hello-whorl"
+author = "Preston Smith, Aidan Dyga, Rebekah Rudd, Jason Gyamafi"
+release = "0.0.13"
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
 
-extensions = ['sphinx.ext.autodoc']
+extensions = ["sphinx.ext.autodoc"]
 
-templates_path = ['_templates']
+templates_path = ["_templates"]
 exclude_patterns = []
 
-language = 'python'
+language = "python"
 
 # -- Options for HTML output -------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
 
-html_theme = 'furo'
-html_static_path = ['_static']
+html_theme = "furo"
+html_static_path = ["_static"]
 html_theme_options = {
     "default_dark_mode": True,
     "dark_css_variables": {
         # Background colors
         "color-background-primary": "#202020",  # Main content background
-        "color-background-secondary": "#202020", # Sidebar background
-        
+        "color-background-secondary": "#202020",  # Sidebar background
         # Text colors
-        "color-foreground-primary": "#d0d0d0", # Main text color
-        "color-foreground-secondary": "#e0b027", # Secondary text color
-        
+        "color-foreground-primary": "#ffffff",  # Main text color
+        "color-foreground-secondary": "#e0b027",  # Secondary text color
         # Link colors
-        "color-brand-primary": "#e2ad2b", # Primary brand color
-        "color-brand-content": "#e2ad2b", # Link color
-        "color-link": "#e2ad2b", # Normal links
-        "color-link-hover": "#CEAFF4", # Hover state
-        "color-link-visited": "#CEAFF4", # Visited links
-        
+        "color-brand-primary": "#e2ad2b",  # Primary brand color
+        "color-brand-content": "#e2ad2b",  # Link color
+        "color-link": "#e2ad2b",  # Normal links
+        "color-link-hover": "#CEAFF4",  # Hover state
+        "color-link-visited": "#CEAFF4",  # Visited links
         # Sidebar colors
-        "color-sidebar-link-text": "#e0b027", # Sidebar link color
-        "color-sidebar-link-text--top-level": "#e2ad2b", # Top level sidebar links
-        
+        "color-sidebar-link-text": "#e0b027",  # Sidebar link color
+        "color-sidebar-link-text--top-level": "#e2ad2b",  # Top level sidebar links
         # API/Code colors
-        "color-api-name": "#e2ad2b", # Function names
-        "color-api-pre-name": "#e2ad2b", # Class/module names
+        "color-api-name": "#e2ad2b",  # Function names
+        "color-api-pre-name": "#e2ad2b",  # Class/module names
+        "color-highlight-on-target": "#56595d",
     },
 }

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -31,6 +31,7 @@ language = 'python'
 html_theme = 'furo'
 html_static_path = ['_static']
 html_theme_options = {
+    "default_dark_mode": True,
     "dark_css_variables": {
         # Background colors
         "color-background-primary": "#202020",  # Main content background

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -45,7 +45,7 @@ html_theme_options = {
         "color-brand-primary": "#e2ad2b", # Primary brand color
         "color-brand-content": "#e2ad2b", # Link color
         "color-link": "#e2ad2b", # Normal links
-        "color-link-hover": "#ffffff", # Hover state
+        "color-link-hover": "#CEAFF4", # Hover state
         "color-link-visited": "#CEAFF4", # Visited links
         
         # Sidebar colors

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -41,15 +41,18 @@ html_theme_options = {
         "color-foreground-secondary": "#e0b027", # Secondary text color
         
         # Link colors
-        "color-brand-primary": "#e69824", # Primary brand color
-        "color-brand-content": "#e69824", # Link color
+        "color-brand-primary": "#e2ad2b", # Primary brand color
+        "color-brand-content": "#e2ad2b", # Link color
+        "color-link": "#e2ad2b", # Normal links
+        "color-link-hover": "#e0b027", # Hover state
+        "color-link-visited": "#e2ad2b", # Visited links
         
         # Sidebar colors
         "color-sidebar-link-text": "#e0b027", # Sidebar link color
-        "color-sidebar-link-text--top-level": "#e69824", # Top level sidebar links
+        "color-sidebar-link-text--top-level": "#e2ad2b", # Top level sidebar links
         
         # API/Code colors
-        "color-api-name": "#e69824", # Function names
-        "color-api-pre-name": "#e69824", # Class/module names
+        "color-api-name": "#e2ad2b", # Function names
+        "color-api-pre-name": "#e2ad2b", # Class/module names
     },
 }


### PR DESCRIPTION
This pull request introduces a default dark mode as well as color changes to the hover and on-target tags.

<img width="1291" alt="Screenshot 2025-01-30 at 3 16 08 PM" src="https://github.com/user-attachments/assets/f6ce0a00-c32a-4d2e-9c8f-9de511fb253b" />

<img width="1398" alt="Screenshot 2025-01-30 at 3 15 50 PM" src="https://github.com/user-attachments/assets/8ab79d56-51a9-482a-a772-9fe2d9ae5f67" />
